### PR TITLE
Replace i18n-iso-modules dependency in bundle with minified country list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .idea/
 npm-debug.log
+/generated

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+	"useTabs": true,
+	"printWidth": 128,
+	"trailingComma": "none",
+	"singleQuote": true
+}

--- a/index.js
+++ b/index.js
@@ -1,213 +1,210 @@
-var assert = require("assert-plus");
-var i18nisocountries = require("./generated/country-list.js");
+var assert = require('assert-plus');
+var i18nisocountries = require('./generated/country-list.js');
 
 var PSEUDO_COUNTRY_CODES = {
-  XS: true,
-  XA: true,
-  XB: true,
-  XC: true,
-  XD: true,
-  XF: true,
-  QS: true,
-  QT: true,
-  QW: true,
+	XS: true,
+	XA: true,
+	XB: true,
+	XC: true,
+	XD: true,
+	XF: true,
+	QS: true,
+	QT: true,
+	QW: true
 };
 
 function ret(callback, err) {
-  "use strict";
+	'use strict';
 
-  if (callback !== undefined) {
-    callback(err);
-    return;
-  }
-  return err;
+	if (callback !== undefined) {
+		callback(err);
+		return;
+	}
+	return err;
 }
 
 function calcCrossSum(i) {
-  "use strict";
-  var qs = 0;
+	'use strict';
+	var qs = 0;
 
-  do {
-    qs += i % 10;
-    i = Math.floor(i / 10);
-  } while (i > 0);
-  return qs;
+	do {
+		qs += i % 10;
+		i = Math.floor(i / 10);
+	} while (i > 0);
+	return qs;
 }
 
 function calculateCheckDigit(countryCode, NSIN) {
-  "use strict";
-  var i,
-    c,
-    s = countryCode + NSIN,
-    nums = [],
-    weights = [],
-    crossSum = 0,
-    diff;
+	'use strict';
+	var i,
+		c,
+		s = countryCode + NSIN,
+		nums = [],
+		weights = [],
+		crossSum = 0,
+		diff;
 
-  for (i = 0; i < s.length; i += 1) {
-    c = s[i];
-    if (c === "0") {
-      nums.push(0);
-    } else if (c === "1") {
-      nums.push(1);
-    } else if (c === "2") {
-      nums.push(2);
-    } else if (c === "3") {
-      nums.push(3);
-    } else if (c === "4") {
-      nums.push(4);
-    } else if (c === "5") {
-      nums.push(5);
-    } else if (c === "6") {
-      nums.push(6);
-    } else if (c === "7") {
-      nums.push(7);
-    } else if (c === "8") {
-      nums.push(8);
-    } else if (c === "9") {
-      nums.push(9);
-    } else if (c === "A") {
-      nums.push(1);
-      nums.push(0);
-    } else if (c === "B") {
-      nums.push(1);
-      nums.push(1);
-    } else if (c === "C") {
-      nums.push(1);
-      nums.push(2);
-    } else if (c === "D") {
-      nums.push(1);
-      nums.push(3);
-    } else if (c === "E") {
-      nums.push(1);
-      nums.push(4);
-    } else if (c === "F") {
-      nums.push(1);
-      nums.push(5);
-    } else if (c === "G") {
-      nums.push(1);
-      nums.push(6);
-    } else if (c === "H") {
-      nums.push(1);
-      nums.push(7);
-    } else if (c === "I") {
-      nums.push(1);
-      nums.push(8);
-    } else if (c === "J") {
-      nums.push(1);
-      nums.push(9);
-    } else if (c === "K") {
-      nums.push(2);
-      nums.push(0);
-    } else if (c === "L") {
-      nums.push(2);
-      nums.push(1);
-    } else if (c === "M") {
-      nums.push(2);
-      nums.push(2);
-    } else if (c === "N") {
-      nums.push(2);
-      nums.push(3);
-    } else if (c === "O") {
-      nums.push(2);
-      nums.push(4);
-    } else if (c === "P") {
-      nums.push(2);
-      nums.push(5);
-    } else if (c === "Q") {
-      nums.push(2);
-      nums.push(6);
-    } else if (c === "R") {
-      nums.push(2);
-      nums.push(7);
-    } else if (c === "S") {
-      nums.push(2);
-      nums.push(8);
-    } else if (c === "T") {
-      nums.push(2);
-      nums.push(9);
-    } else if (c === "U") {
-      nums.push(3);
-      nums.push(0);
-    } else if (c === "V") {
-      nums.push(3);
-      nums.push(1);
-    } else if (c === "W") {
-      nums.push(3);
-      nums.push(2);
-    } else if (c === "X") {
-      nums.push(3);
-      nums.push(3);
-    } else if (c === "Y") {
-      nums.push(3);
-      nums.push(4);
-    } else if (c === "Z") {
-      nums.push(3);
-      nums.push(5);
-    }
-  }
-  for (i = 0; i < nums.length; i += 1) {
-    if (i % 2 === 0) {
-      weights.push(2);
-    } else {
-      weights.push(1);
-    }
-  }
-  weights.reverse();
-  for (i = 0; i < nums.length; i += 1) {
-    crossSum += calcCrossSum(nums[i] * weights[i]);
-  }
-  diff = 10 - (crossSum % 10);
-  if (diff === 10) {
-    return 0;
-  }
-  return diff;
+	for (i = 0; i < s.length; i += 1) {
+		c = s[i];
+		if (c === '0') {
+			nums.push(0);
+		} else if (c === '1') {
+			nums.push(1);
+		} else if (c === '2') {
+			nums.push(2);
+		} else if (c === '3') {
+			nums.push(3);
+		} else if (c === '4') {
+			nums.push(4);
+		} else if (c === '5') {
+			nums.push(5);
+		} else if (c === '6') {
+			nums.push(6);
+		} else if (c === '7') {
+			nums.push(7);
+		} else if (c === '8') {
+			nums.push(8);
+		} else if (c === '9') {
+			nums.push(9);
+		} else if (c === 'A') {
+			nums.push(1);
+			nums.push(0);
+		} else if (c === 'B') {
+			nums.push(1);
+			nums.push(1);
+		} else if (c === 'C') {
+			nums.push(1);
+			nums.push(2);
+		} else if (c === 'D') {
+			nums.push(1);
+			nums.push(3);
+		} else if (c === 'E') {
+			nums.push(1);
+			nums.push(4);
+		} else if (c === 'F') {
+			nums.push(1);
+			nums.push(5);
+		} else if (c === 'G') {
+			nums.push(1);
+			nums.push(6);
+		} else if (c === 'H') {
+			nums.push(1);
+			nums.push(7);
+		} else if (c === 'I') {
+			nums.push(1);
+			nums.push(8);
+		} else if (c === 'J') {
+			nums.push(1);
+			nums.push(9);
+		} else if (c === 'K') {
+			nums.push(2);
+			nums.push(0);
+		} else if (c === 'L') {
+			nums.push(2);
+			nums.push(1);
+		} else if (c === 'M') {
+			nums.push(2);
+			nums.push(2);
+		} else if (c === 'N') {
+			nums.push(2);
+			nums.push(3);
+		} else if (c === 'O') {
+			nums.push(2);
+			nums.push(4);
+		} else if (c === 'P') {
+			nums.push(2);
+			nums.push(5);
+		} else if (c === 'Q') {
+			nums.push(2);
+			nums.push(6);
+		} else if (c === 'R') {
+			nums.push(2);
+			nums.push(7);
+		} else if (c === 'S') {
+			nums.push(2);
+			nums.push(8);
+		} else if (c === 'T') {
+			nums.push(2);
+			nums.push(9);
+		} else if (c === 'U') {
+			nums.push(3);
+			nums.push(0);
+		} else if (c === 'V') {
+			nums.push(3);
+			nums.push(1);
+		} else if (c === 'W') {
+			nums.push(3);
+			nums.push(2);
+		} else if (c === 'X') {
+			nums.push(3);
+			nums.push(3);
+		} else if (c === 'Y') {
+			nums.push(3);
+			nums.push(4);
+		} else if (c === 'Z') {
+			nums.push(3);
+			nums.push(5);
+		}
+	}
+	for (i = 0; i < nums.length; i += 1) {
+		if (i % 2 === 0) {
+			weights.push(2);
+		} else {
+			weights.push(1);
+		}
+	}
+	weights.reverse();
+	for (i = 0; i < nums.length; i += 1) {
+		crossSum += calcCrossSum(nums[i] * weights[i]);
+	}
+	diff = 10 - (crossSum % 10);
+	if (diff === 10) {
+		return 0;
+	}
+	return diff;
 }
 
 module.exports = function (ISIN, callback, options) {
-  "use strict";
-  assert.string(ISIN, "ISIN");
-  assert.optionalFunc(callback, "callback");
-  assert.optionalObject(options, "options");
-  options = options || {};
-  var countryCode, NSIN, checkDigit;
+	'use strict';
+	assert.string(ISIN, 'ISIN');
+	assert.optionalFunc(callback, 'callback');
+	assert.optionalObject(options, 'options');
+	options = options || {};
+	var countryCode, NSIN, checkDigit;
 
-  if (ISIN.length !== 12) {
-    return ret(callback, new Error("ISIN must be 12 characters long"));
-  }
+	if (ISIN.length !== 12) {
+		return ret(callback, new Error('ISIN must be 12 characters long'));
+	}
 
-  if (!/^[A-Z0-9]+$/.test(ISIN)) {
-    return ret(callback, new Error("ISIN contains not only [A-Z0-9]"));
-  }
+	if (!/^[A-Z0-9]+$/.test(ISIN)) {
+		return ret(callback, new Error('ISIN contains not only [A-Z0-9]'));
+	}
 
-  countryCode = ISIN.substr(0, 2);
-  if (!/^[A-Z]+$/.test(countryCode)) {
-    return ret(callback, new Error("Country code contains not only [A-Z]"));
-  }
-  if (options.checkCountryCode !== false) {
-    if (
-      PSEUDO_COUNTRY_CODES[countryCode] !== true &&
-      i18nisocountries[countryCode] === undefined
-    ) {
-      return ret(callback, new Error("Country code is wrong"));
-    }
-  }
+	countryCode = ISIN.substr(0, 2);
+	if (!/^[A-Z]+$/.test(countryCode)) {
+		return ret(callback, new Error('Country code contains not only [A-Z]'));
+	}
+	if (options.checkCountryCode !== false) {
+		if (PSEUDO_COUNTRY_CODES[countryCode] !== true && i18nisocountries[countryCode] === undefined) {
+			return ret(callback, new Error('Country code is wrong'));
+		}
+	}
 
-  NSIN = ISIN.substr(2, 9);
-  if (!/^[A-Z0-9]+$/.test(NSIN)) {
-    return ret(callback, new Error("NSIN contains not only [A-Z0-9]"));
-  }
+	NSIN = ISIN.substr(2, 9);
+	if (!/^[A-Z0-9]+$/.test(NSIN)) {
+		return ret(callback, new Error('NSIN contains not only [A-Z0-9]'));
+	}
 
-  checkDigit = ISIN[11];
-  if (!/^[0-9]+$/.test(checkDigit)) {
-    return ret(callback, new Error("Check digit contains not only [0-9]"));
-  }
-  if (options.checkCheckDigit !== false) {
-    checkDigit = parseInt(checkDigit, 10);
-    if (checkDigit !== calculateCheckDigit(countryCode, NSIN)) {
-      return ret(callback, new Error("Check digit is wrong"));
-    }
-  }
+	checkDigit = ISIN[11];
+	if (!/^[0-9]+$/.test(checkDigit)) {
+		return ret(callback, new Error('Check digit contains not only [0-9]'));
+	}
+	if (options.checkCheckDigit !== false) {
+		checkDigit = parseInt(checkDigit, 10);
+		if (checkDigit !== calculateCheckDigit(countryCode, NSIN)) {
+			return ret(callback, new Error('Check digit is wrong'));
+		}
+	}
 
-  return ret(callback, undefined);
+	return ret(callback, undefined);
 };

--- a/index.js
+++ b/index.js
@@ -1,204 +1,213 @@
-var assert = require("assert-plus"),
-	i18nisocountries = require("i18n-iso-countries");
+var assert = require("assert-plus");
+var i18nisocountries = require("./generated/country-list.js");
 
 var PSEUDO_COUNTRY_CODES = {
-	XS: true,
-	XA: true,
-	XB: true,
-	XC: true,
-	XD: true,
-	XF: true,
-	QS: true,
-	QT: true,
-	QW: true
+  XS: true,
+  XA: true,
+  XB: true,
+  XC: true,
+  XD: true,
+  XF: true,
+  QS: true,
+  QT: true,
+  QW: true,
 };
 
 function ret(callback, err) {
-	"use strict";
+  "use strict";
 
-	if (callback !== undefined) {
-		callback(err);
-		return;
-	}
-	return err;
+  if (callback !== undefined) {
+    callback(err);
+    return;
+  }
+  return err;
 }
 
 function calcCrossSum(i) {
-	"use strict";
-	var qs = 0;
+  "use strict";
+  var qs = 0;
 
-	do {
-		qs += i % 10;
-		i = Math.floor(i/10);
-	} while (i > 0);
-	return qs;
+  do {
+    qs += i % 10;
+    i = Math.floor(i / 10);
+  } while (i > 0);
+  return qs;
 }
 
 function calculateCheckDigit(countryCode, NSIN) {
-	"use strict";
-	var i, c, s = countryCode + NSIN, nums = [], weights = [], crossSum = 0, diff;
+  "use strict";
+  var i,
+    c,
+    s = countryCode + NSIN,
+    nums = [],
+    weights = [],
+    crossSum = 0,
+    diff;
 
-	for (i = 0; i < s.length; i += 1) {
-		c = s[i];
-		if (c === '0') {
-			nums.push(0);
-		} else if (c === '1') {
-			nums.push(1);
-		} else if (c === '2') {
-			nums.push(2);
-		} else if (c === '3') {
-			nums.push(3);
-		} else if (c === '4') {
-			nums.push(4);
-		} else if (c === '5') {
-			nums.push(5);
-		} else if (c === '6') {
-			nums.push(6);
-		} else if (c === '7') {
-			nums.push(7);
-		} else if (c === '8') {
-			nums.push(8);
-		} else if (c === '9') {
-			nums.push(9);
-		} else if (c === 'A') {
-			nums.push(1);
-			nums.push(0);
-		} else if (c === 'B') {
-			nums.push(1);
-			nums.push(1);
-		} else if (c === 'C') {
-			nums.push(1);
-			nums.push(2);
-		} else if (c === 'D') {
-			nums.push(1);
-			nums.push(3);
-		} else if (c === 'E') {
-			nums.push(1);
-			nums.push(4);
-		} else if (c === 'F') {
-			nums.push(1);
-			nums.push(5);
-		} else if (c === 'G') {
-			nums.push(1);
-			nums.push(6);
-		} else if (c === 'H') {
-			nums.push(1);
-			nums.push(7);
-		} else if (c === 'I') {
-			nums.push(1);
-			nums.push(8);
-		} else if (c === 'J') {
-			nums.push(1);
-			nums.push(9);
-		} else if (c === 'K') {
-			nums.push(2);
-			nums.push(0);
-		} else if (c === 'L') {
-			nums.push(2);
-			nums.push(1);
-		} else if (c === 'M') {
-			nums.push(2);
-			nums.push(2);
-		} else if (c === 'N') {
-			nums.push(2);
-			nums.push(3);
-		} else if (c === 'O') {
-			nums.push(2);
-			nums.push(4);
-		} else if (c === 'P') {
-			nums.push(2);
-			nums.push(5);
-		} else if (c === 'Q') {
-			nums.push(2);
-			nums.push(6);
-		} else if (c === 'R') {
-			nums.push(2);
-			nums.push(7);
-		} else if (c === 'S') {
-			nums.push(2);
-			nums.push(8);
-		} else if (c === 'T') {
-			nums.push(2);
-			nums.push(9);
-		} else if (c === 'U') {
-			nums.push(3);
-			nums.push(0);
-		} else if (c === 'V') {
-			nums.push(3);
-			nums.push(1);
-		} else if (c === 'W') {
-			nums.push(3);
-			nums.push(2);
-		} else if (c === 'X') {
-			nums.push(3);
-			nums.push(3);
-		} else if (c === 'Y') {
-			nums.push(3);
-			nums.push(4);
-		} else if (c === 'Z') {
-			nums.push(3);
-			nums.push(5);
-		}
-	}
-	for (i = 0; i < nums.length; i += 1) {
-		if (i % 2 === 0) {
-			weights.push(2);
-		} else {
-			weights.push(1);
-		}
-	}
-	weights.reverse();
-	for (i = 0; i < nums.length; i += 1) {
-		crossSum += calcCrossSum(nums[i] * weights[i]);
-	}
-	diff = 10 - (crossSum % 10);
-	if (diff === 10) {
-		return 0;
-	}
-	return diff;
+  for (i = 0; i < s.length; i += 1) {
+    c = s[i];
+    if (c === "0") {
+      nums.push(0);
+    } else if (c === "1") {
+      nums.push(1);
+    } else if (c === "2") {
+      nums.push(2);
+    } else if (c === "3") {
+      nums.push(3);
+    } else if (c === "4") {
+      nums.push(4);
+    } else if (c === "5") {
+      nums.push(5);
+    } else if (c === "6") {
+      nums.push(6);
+    } else if (c === "7") {
+      nums.push(7);
+    } else if (c === "8") {
+      nums.push(8);
+    } else if (c === "9") {
+      nums.push(9);
+    } else if (c === "A") {
+      nums.push(1);
+      nums.push(0);
+    } else if (c === "B") {
+      nums.push(1);
+      nums.push(1);
+    } else if (c === "C") {
+      nums.push(1);
+      nums.push(2);
+    } else if (c === "D") {
+      nums.push(1);
+      nums.push(3);
+    } else if (c === "E") {
+      nums.push(1);
+      nums.push(4);
+    } else if (c === "F") {
+      nums.push(1);
+      nums.push(5);
+    } else if (c === "G") {
+      nums.push(1);
+      nums.push(6);
+    } else if (c === "H") {
+      nums.push(1);
+      nums.push(7);
+    } else if (c === "I") {
+      nums.push(1);
+      nums.push(8);
+    } else if (c === "J") {
+      nums.push(1);
+      nums.push(9);
+    } else if (c === "K") {
+      nums.push(2);
+      nums.push(0);
+    } else if (c === "L") {
+      nums.push(2);
+      nums.push(1);
+    } else if (c === "M") {
+      nums.push(2);
+      nums.push(2);
+    } else if (c === "N") {
+      nums.push(2);
+      nums.push(3);
+    } else if (c === "O") {
+      nums.push(2);
+      nums.push(4);
+    } else if (c === "P") {
+      nums.push(2);
+      nums.push(5);
+    } else if (c === "Q") {
+      nums.push(2);
+      nums.push(6);
+    } else if (c === "R") {
+      nums.push(2);
+      nums.push(7);
+    } else if (c === "S") {
+      nums.push(2);
+      nums.push(8);
+    } else if (c === "T") {
+      nums.push(2);
+      nums.push(9);
+    } else if (c === "U") {
+      nums.push(3);
+      nums.push(0);
+    } else if (c === "V") {
+      nums.push(3);
+      nums.push(1);
+    } else if (c === "W") {
+      nums.push(3);
+      nums.push(2);
+    } else if (c === "X") {
+      nums.push(3);
+      nums.push(3);
+    } else if (c === "Y") {
+      nums.push(3);
+      nums.push(4);
+    } else if (c === "Z") {
+      nums.push(3);
+      nums.push(5);
+    }
+  }
+  for (i = 0; i < nums.length; i += 1) {
+    if (i % 2 === 0) {
+      weights.push(2);
+    } else {
+      weights.push(1);
+    }
+  }
+  weights.reverse();
+  for (i = 0; i < nums.length; i += 1) {
+    crossSum += calcCrossSum(nums[i] * weights[i]);
+  }
+  diff = 10 - (crossSum % 10);
+  if (diff === 10) {
+    return 0;
+  }
+  return diff;
 }
 
-module.exports = function(ISIN, callback, options) {
-	"use strict";
-	assert.string(ISIN, "ISIN");
-	assert.optionalFunc(callback, "callback");
-	assert.optionalObject(options, "options");
-	options = options || {};
-	var countryCode, NSIN, checkDigit;
+module.exports = function (ISIN, callback, options) {
+  "use strict";
+  assert.string(ISIN, "ISIN");
+  assert.optionalFunc(callback, "callback");
+  assert.optionalObject(options, "options");
+  options = options || {};
+  var countryCode, NSIN, checkDigit;
 
-	if (ISIN.length !== 12) {
-		return ret(callback, new Error("ISIN must be 12 characters long"));
-	}
+  if (ISIN.length !== 12) {
+    return ret(callback, new Error("ISIN must be 12 characters long"));
+  }
 
-	if (!/^[A-Z0-9]+$/.test(ISIN)) {
-		return ret(callback, new Error("ISIN contains not only [A-Z0-9]"));
-	}
+  if (!/^[A-Z0-9]+$/.test(ISIN)) {
+    return ret(callback, new Error("ISIN contains not only [A-Z0-9]"));
+  }
 
-	countryCode = ISIN.substr(0, 2);
-	if (!/^[A-Z]+$/.test(countryCode)) {
-		return ret(callback, new Error("Country code contains not only [A-Z]"));
-	}
-	if (options.checkCountryCode !== false) {
-		if (PSEUDO_COUNTRY_CODES[countryCode] !== true && i18nisocountries.getName(countryCode, "de") === undefined) {
-			return ret(callback, new Error("Country code is wrong"));
-		}
-	}
+  countryCode = ISIN.substr(0, 2);
+  if (!/^[A-Z]+$/.test(countryCode)) {
+    return ret(callback, new Error("Country code contains not only [A-Z]"));
+  }
+  if (options.checkCountryCode !== false) {
+    if (
+      PSEUDO_COUNTRY_CODES[countryCode] !== true &&
+      i18nisocountries[countryCode] === undefined
+    ) {
+      return ret(callback, new Error("Country code is wrong"));
+    }
+  }
 
-	NSIN = ISIN.substr(2, 9);
-	if (!/^[A-Z0-9]+$/.test(NSIN)) {
-		return ret(callback, new Error("NSIN contains not only [A-Z0-9]"));
-	}
+  NSIN = ISIN.substr(2, 9);
+  if (!/^[A-Z0-9]+$/.test(NSIN)) {
+    return ret(callback, new Error("NSIN contains not only [A-Z0-9]"));
+  }
 
-	checkDigit = ISIN[11];
-	if (!/^[0-9]+$/.test(checkDigit)) {
-		return ret(callback, new Error("Check digit contains not only [0-9]"));
-	}
-	if (options.checkCheckDigit !== false) {
-		checkDigit = parseInt(checkDigit, 10);
-		if (checkDigit !== calculateCheckDigit(countryCode, NSIN)) {
-			return ret(callback, new Error("Check digit is wrong"));
-		}
-	}
+  checkDigit = ISIN[11];
+  if (!/^[0-9]+$/.test(checkDigit)) {
+    return ret(callback, new Error("Check digit contains not only [0-9]"));
+  }
+  if (options.checkCheckDigit !== false) {
+    checkDigit = parseInt(checkDigit, 10);
+    if (checkDigit !== calculateCheckDigit(countryCode, NSIN)) {
+      return ret(callback, new Error("Check digit is wrong"));
+    }
+  }
 
-	return ret(callback, undefined);
+  return ret(callback, undefined);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,12 @@
 				"uglify-js": "~1.2.5"
 			}
 		},
+		"diacritics": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+			"integrity": "sha1-PvqHMj67hj5mls67AILUj/PW96E=",
+			"dev": true
+		},
 		"diff": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
@@ -176,9 +182,13 @@
 			"dev": true
 		},
 		"i18n-iso-countries": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-0.0.2.tgz",
-			"integrity": "sha1-rS49zl0NwW7CEhp+m2+d8ODsUPc="
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-6.2.2.tgz",
+			"integrity": "sha512-sZJeKs5IP93Y+dq/8/NonrEdOudVVuH6BbZVd66edjxVkKVFMtvbM6EkpTbDO3B+d9qFW9XZqdgmGNgNDzciSw==",
+			"dev": true,
+			"requires": {
+				"diacritics": "1.3.0"
+			}
 		},
 		"inherits": {
 			"version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,44 +1,45 @@
 {
-	"name": "cinovo-isin-validator",
-	"version": "0.2.0",
-	"description": "International Securities Identification Number validator",
-	"keywords": [
-		"ISIN",
-		"International",
-		"Securities",
-		"Identification",
-		"Number",
-		"validator"
-	],
-	"author": {
-		"name": "Michael Wittig",
-		"email": "post@michaelwittig.info"
-	},
-	"contributors": [],
-	"license": "MIT",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/michaelwittig/node-isin-validator.git"
-	},
-	"dependencies": {
-		"assert-plus": "0.1.5",
-		"i18n-iso-countries": "0.0.2"
-	},
-	"devDependencies": {
-		"mocha": "1.15.1",
-		"jslint": "0.2.5",
-		"madge": "0.1.7",
-		"npmedge": "0.1.4"
-	},
-	"main": "index",
-	"engines": {
-		"node": ">= 0.6.0"
-	},
-	"scripts": {
-		"test": "make test"
-	},
-	"readmeFilename": "README.md",
-	"bugs": {
-		"url": "https://github.com/michaelwittig/node-isin-validator/issues"
-	}
+  "name": "cinovo-isin-validator",
+  "version": "0.2.0",
+  "description": "International Securities Identification Number validator",
+  "keywords": [
+    "ISIN",
+    "International",
+    "Securities",
+    "Identification",
+    "Number",
+    "validator"
+  ],
+  "author": {
+    "name": "Michael Wittig",
+    "email": "post@michaelwittig.info"
+  },
+  "contributors": [],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/michaelwittig/node-isin-validator.git"
+  },
+  "dependencies": {
+    "assert-plus": "0.1.5"
+  },
+  "devDependencies": {
+    "i18n-iso-countries": "^6.2.2",
+    "jslint": "0.2.5",
+    "madge": "0.1.7",
+    "mocha": "1.15.1",
+    "npmedge": "0.1.4"
+  },
+  "main": "index",
+  "engines": {
+    "node": ">= 0.6.0"
+  },
+  "scripts": {
+    "install": "node script/generate-country-list.js",
+    "test": "make test"
+  },
+  "readmeFilename": "README.md",
+  "bugs": {
+    "url": "https://github.com/michaelwittig/node-isin-validator/issues"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,45 +1,45 @@
 {
-  "name": "cinovo-isin-validator",
-  "version": "0.2.0",
-  "description": "International Securities Identification Number validator",
-  "keywords": [
-    "ISIN",
-    "International",
-    "Securities",
-    "Identification",
-    "Number",
-    "validator"
-  ],
-  "author": {
-    "name": "Michael Wittig",
-    "email": "post@michaelwittig.info"
-  },
-  "contributors": [],
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/michaelwittig/node-isin-validator.git"
-  },
-  "dependencies": {
-    "assert-plus": "0.1.5"
-  },
-  "devDependencies": {
-    "i18n-iso-countries": "^6.2.2",
-    "jslint": "0.2.5",
-    "madge": "0.1.7",
-    "mocha": "1.15.1",
-    "npmedge": "0.1.4"
-  },
-  "main": "index",
-  "engines": {
-    "node": ">= 0.6.0"
-  },
-  "scripts": {
-    "install": "node script/generate-country-list.js",
-    "test": "make test"
-  },
-  "readmeFilename": "README.md",
-  "bugs": {
-    "url": "https://github.com/michaelwittig/node-isin-validator/issues"
-  }
+	"name": "cinovo-isin-validator",
+	"version": "0.2.0",
+	"description": "International Securities Identification Number validator",
+	"keywords": [
+		"ISIN",
+		"International",
+		"Securities",
+		"Identification",
+		"Number",
+		"validator"
+	],
+	"author": {
+		"name": "Michael Wittig",
+		"email": "post@michaelwittig.info"
+	},
+	"contributors": [],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/michaelwittig/node-isin-validator.git"
+	},
+	"dependencies": {
+		"assert-plus": "0.1.5"
+	},
+	"devDependencies": {
+		"i18n-iso-countries": "^6.2.2",
+		"jslint": "0.2.5",
+		"madge": "0.1.7",
+		"mocha": "1.15.1",
+		"npmedge": "0.1.4"
+	},
+	"main": "index",
+	"engines": {
+		"node": ">= 0.6.0"
+	},
+	"scripts": {
+		"install": "node script/generate-country-list.js",
+		"test": "make test"
+	},
+	"readmeFilename": "README.md",
+	"bugs": {
+		"url": "https://github.com/michaelwittig/node-isin-validator/issues"
+	}
 }

--- a/script/generate-country-list.js
+++ b/script/generate-country-list.js
@@ -1,0 +1,18 @@
+var fs = require("fs");
+var path = require("path");
+
+console.log("Generating country-list.js ...");
+
+var dataFile = path.join(__dirname, "../node_modules/i18n-iso-countries/langs/de.json");
+var outDir = path.join(__dirname, "../generated");
+var outFile = path.join(outDir, "country-list.js");
+
+if (!fs.existsSync(outDir)) {
+  fs.mkdirSync(outDir);
+}
+
+var data = JSON.parse(fs.readFileSync(dataFile).toString());
+var countries = Object.keys(data.countries);
+var code = "module.exports = " + JSON.stringify(countries) + ";";
+
+fs.writeFileSync(outFile, code);

--- a/script/generate-country-list.js
+++ b/script/generate-country-list.js
@@ -1,18 +1,18 @@
-var fs = require("fs");
-var path = require("path");
+var fs = require('fs');
+var path = require('path');
 
-console.log("Generating country-list.js ...");
+console.log('Generating country-list.js ...');
 
-var dataFile = path.join(__dirname, "../node_modules/i18n-iso-countries/langs/de.json");
-var outDir = path.join(__dirname, "../generated");
-var outFile = path.join(outDir, "country-list.js");
+var dataFile = path.join(__dirname, '../node_modules/i18n-iso-countries/langs/de.json');
+var outDir = path.join(__dirname, '../generated');
+var outFile = path.join(outDir, 'country-list.js');
 
 if (!fs.existsSync(outDir)) {
-  fs.mkdirSync(outDir);
+	fs.mkdirSync(outDir);
 }
 
 var data = JSON.parse(fs.readFileSync(dataFile).toString());
 var countries = Object.keys(data.countries);
-var code = "module.exports = " + JSON.stringify(countries) + ";";
+var code = 'module.exports = ' + JSON.stringify(countries) + ';';
 
 fs.writeFileSync(outFile, code);


### PR DESCRIPTION
This MR changes the integration of the i18n-iso-countries dependency to achieve a smaller bundle size.

Instead of `require()`ing the module directly, `index.js` now loads a much smaller country list which is generated from the original source.

The generator script is in `script/generate-country-list.js` and writes to `generated/country-list.js`. A new `install` hook in `package.json` ensures that the script is executed upon local installation of the module. The script output folder is also new and was added to `.gitignore` to prevent accidental commits of the generated file.
